### PR TITLE
Update - Fixes Support for Win7 and Server2012R2

### DIFF
--- a/WindowsMonitor.Standard/Hardware/Bios/BIOS.cs
+++ b/WindowsMonitor.Standard/Hardware/Bios/BIOS.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Management;
 
@@ -8,37 +8,37 @@ namespace WindowsMonitor.Hardware.Bios
     /// </summary>
     public sealed class Bios
     {
-		public ushort[] BiosCharacteristics { get; private set; }
-		public string[] BiosVersion { get; private set; }
-		public string BuildNumber { get; private set; }
-		public string Caption { get; private set; }
-		public string CodeSet { get; private set; }
-		public string CurrentLanguage { get; private set; }
-		public string Description { get; private set; }
-		public byte EmbeddedControllerMajorVersion { get; private set; }
-		public byte EmbeddedControllerMinorVersion { get; private set; }
-		public string IdentificationCode { get; private set; }
-		public ushort InstallableLanguages { get; private set; }
-		public DateTime InstallDate { get; private set; }
-		public string LanguageEdition { get; private set; }
-		public string[] ListOfLanguages { get; private set; }
-		public string Manufacturer { get; private set; }
-		public string Name { get; private set; }
-		public string OtherTargetOs { get; private set; }
-		public bool PrimaryBios { get; private set; }
-		public DateTime ReleaseDate { get; private set; }
-		public string SerialNumber { get; private set; }
-		public string SmbiosbiosVersion { get; private set; }
-		public ushort SmbiosMajorVersion { get; private set; }
-		public ushort SmbiosMinorVersion { get; private set; }
-		public bool SmbiosPresent { get; private set; }
-		public string SoftwareElementId { get; private set; }
-		public ushort SoftwareElementState { get; private set; }
-		public string Status { get; private set; }
-		public byte SystemBiosMajorVersion { get; private set; }
-		public byte SystemBiosMinorVersion { get; private set; }
-		public ushort TargetOperatingSystem { get; private set; }
-		public string Version { get; private set; }
+        public ushort[] BiosCharacteristics { get; private set; }
+        public string[] BiosVersion { get; private set; }
+        public string BuildNumber { get; private set; }
+        public string Caption { get; private set; }
+        public string CodeSet { get; private set; }
+        public string CurrentLanguage { get; private set; }
+        public string Description { get; private set; }
+        public byte EmbeddedControllerMajorVersion { get; private set; }
+        public byte EmbeddedControllerMinorVersion { get; private set; }
+        public string IdentificationCode { get; private set; }
+        public ushort InstallableLanguages { get; private set; }
+        public DateTime InstallDate { get; private set; }
+        public string LanguageEdition { get; private set; }
+        public string[] ListOfLanguages { get; private set; }
+        public string Manufacturer { get; private set; }
+        public string Name { get; private set; }
+        public string OtherTargetOs { get; private set; }
+        public bool PrimaryBios { get; private set; }
+        public DateTime ReleaseDate { get; private set; }
+        public string SerialNumber { get; private set; }
+        public string SmbiosbiosVersion { get; private set; }
+        public ushort SmbiosMajorVersion { get; private set; }
+        public ushort SmbiosMinorVersion { get; private set; }
+        public bool SmbiosPresent { get; private set; }
+        public string SoftwareElementId { get; private set; }
+        public ushort SoftwareElementState { get; private set; }
+        public string Status { get; private set; }
+        public byte SystemBiosMajorVersion { get; private set; }
+        public byte SystemBiosMinorVersion { get; private set; }
+        public ushort TargetOperatingSystem { get; private set; }
+        public string Version { get; private set; }
 
         public static IEnumerable<Bios> Retrieve(string remote, string username, string password)
         {
@@ -61,6 +61,29 @@ namespace WindowsMonitor.Hardware.Bios
             return Retrieve(managementScope);
         }
 
+        public static T ReturnDetail<T>(String Name, ManagementObject obj, T DefaultObj)
+        {
+            try
+            {
+                if (obj.Properties[Name] != null)
+                {
+                    if (obj.Properties[Name].Value != null)
+                    {
+                        return (T)(obj.Properties[Name].Value);
+                    }
+                    else
+                    {
+                        return DefaultObj;
+                    }
+                }
+                else
+                {
+                    return DefaultObj;
+                }
+            }
+            catch { return DefaultObj; }
+        }
+
         public static IEnumerable<Bios> Retrieve(ManagementScope managementScope)
         {
             var objectQuery = new ObjectQuery("SELECT * FROM Win32_BIOS");
@@ -68,40 +91,43 @@ namespace WindowsMonitor.Hardware.Bios
             var objectCollection = objectSearcher.Get();
 
             foreach (ManagementObject managementObject in objectCollection)
+            {
+                ushort v = ReturnDetail<ushort>("SMBIOSMinorVersion", managementObject, default(ushort));
                 yield return new Bios
                 {
-                     BiosCharacteristics = (ushort[]) (managementObject.Properties["BiosCharacteristics"]?.Value ?? new ushort[0]),
-		 BiosVersion = (string[]) (managementObject.Properties["BIOSVersion"]?.Value ?? new string[0]),
-		 BuildNumber = (string) (managementObject.Properties["BuildNumber"]?.Value),
-		 Caption = (string) (managementObject.Properties["Caption"]?.Value),
-		 CodeSet = (string) (managementObject.Properties["CodeSet"]?.Value),
-		 CurrentLanguage = (string) (managementObject.Properties["CurrentLanguage"]?.Value),
-		 Description = (string) (managementObject.Properties["Description"]?.Value),
-		 EmbeddedControllerMajorVersion = (byte) (managementObject.Properties["EmbeddedControllerMajorVersion"]?.Value ?? default(byte)),
-		 EmbeddedControllerMinorVersion = (byte) (managementObject.Properties["EmbeddedControllerMinorVersion"]?.Value ?? default(byte)),
-		 IdentificationCode = (string) (managementObject.Properties["IdentificationCode"]?.Value),
-		 InstallableLanguages = (ushort) (managementObject.Properties["InstallableLanguages"]?.Value ?? default(ushort)),
-		 InstallDate = ManagementDateTimeConverter.ToDateTime (managementObject.Properties["InstallDate"]?.Value as string ?? "00010102000000.000000+060"),
-		 LanguageEdition = (string) (managementObject.Properties["LanguageEdition"]?.Value),
-		 ListOfLanguages = (string[]) (managementObject.Properties["ListOfLanguages"]?.Value ?? new string[0]),
-		 Manufacturer = (string) (managementObject.Properties["Manufacturer"]?.Value),
-		 Name = (string) (managementObject.Properties["Name"]?.Value),
-		 OtherTargetOs = (string) (managementObject.Properties["OtherTargetOS"]?.Value),
-		 PrimaryBios = (bool) (managementObject.Properties["PrimaryBIOS"]?.Value ?? default(bool)),
-		 ReleaseDate = ManagementDateTimeConverter.ToDateTime (managementObject.Properties["ReleaseDate"]?.Value as string ?? "00010102000000.000000+060"),
-		 SerialNumber = (string) (managementObject.Properties["SerialNumber"]?.Value),
-		 SmbiosbiosVersion = (string) (managementObject.Properties["SMBIOSBIOSVersion"]?.Value),
-		 SmbiosMajorVersion = (ushort) (managementObject.Properties["SMBIOSMajorVersion"]?.Value ?? default(ushort)),
-		 SmbiosMinorVersion = (ushort) (managementObject.Properties["SMBIOSMinorVersion"]?.Value ?? default(ushort)),
-		 SmbiosPresent = (bool) (managementObject.Properties["SMBIOSPresent"]?.Value ?? default(bool)),
-		 SoftwareElementId = (string) (managementObject.Properties["SoftwareElementID"]?.Value),
-		 SoftwareElementState = (ushort) (managementObject.Properties["SoftwareElementState"]?.Value ?? default(ushort)),
-		 Status = (string) (managementObject.Properties["Status"]?.Value),
-		 SystemBiosMajorVersion = (byte) (managementObject.Properties["SystemBiosMajorVersion"]?.Value ?? default(byte)),
-		 SystemBiosMinorVersion = (byte) (managementObject.Properties["SystemBiosMinorVersion"]?.Value ?? default(byte)),
-		 TargetOperatingSystem = (ushort) (managementObject.Properties["TargetOperatingSystem"]?.Value ?? default(ushort)),
-		 Version = (string) (managementObject.Properties["Version"]?.Value)
+                    BiosCharacteristics = ReturnDetail("BiosCharacteristics", managementObject, new ushort[0]),
+                    BiosVersion = ReturnDetail("BIOSVersion", managementObject, new string[0]),
+                    BuildNumber = ReturnDetail("BuildNumber", managementObject, ""),
+                    Caption = ReturnDetail("Caption", managementObject, ""),
+                    CodeSet = ReturnDetail("CodeSet", managementObject, ""),
+                    CurrentLanguage = ReturnDetail("CurrentLanguage", managementObject, ""),
+                    Description = ReturnDetail("Description", managementObject, ""),
+                    EmbeddedControllerMajorVersion = ReturnDetail<byte>("EmbeddedControllerMajorVersion", managementObject, default(byte)),
+                    EmbeddedControllerMinorVersion = ReturnDetail<byte>("EmbeddedControllerMinorVersion", managementObject, default(byte)),
+                    IdentificationCode = ReturnDetail("IdentificationCode", managementObject, ""),
+                    InstallableLanguages = ReturnDetail<ushort>("InstallableLanguages", managementObject, default(ushort)),
+                    InstallDate = ManagementDateTimeConverter.ToDateTime(ReturnDetail<string>("InstallDate", managementObject, "00010102000000.000000+060")),
+                    LanguageEdition = ReturnDetail("LanguageEdition", managementObject, ""),
+                    ListOfLanguages = ReturnDetail<string[]>("ListOfLanguages", managementObject, new string[0]),
+                    Manufacturer = ReturnDetail("Manufacturer", managementObject, ""),
+                    Name = ReturnDetail("Name", managementObject, ""),
+                    OtherTargetOs = ReturnDetail("OtherTargetOS", managementObject, ""),
+                    PrimaryBios = ReturnDetail<bool>("PrimaryBIOS", managementObject, default(bool)),
+                    ReleaseDate = ManagementDateTimeConverter.ToDateTime( ReturnDetail<string>("ReleaseDate", managementObject, "00010102000000.000000+060")),
+                    SerialNumber = ReturnDetail("SerialNumber", managementObject, ""),
+                    SmbiosbiosVersion = ReturnDetail("SMBIOSBIOSVersion", managementObject, ""),
+                    SmbiosMajorVersion = ReturnDetail("SMBIOSMajorVersion", managementObject, default(ushort)),
+                    SmbiosMinorVersion = v,
+                    SmbiosPresent = ReturnDetail<bool>("SMBIOSPresent", managementObject, default(bool)),
+                    SoftwareElementId = ReturnDetail("SoftwareElementID", managementObject, ""),
+                    SoftwareElementState = ReturnDetail<ushort>("SoftwareElementState", managementObject, default(ushort)),
+                    Status = ReturnDetail("Status", managementObject, ""),
+                    SystemBiosMajorVersion = ReturnDetail<byte>("SystemBiosMajorVersion", managementObject, default(byte)),
+                    SystemBiosMinorVersion = ReturnDetail<byte>("SystemBiosMinorVersion", managementObject, default(byte)),
+                    TargetOperatingSystem = ReturnDetail<ushort>("TargetOperatingSystem", managementObject, default(ushort)),
+                    Version = ReturnDetail("Version", managementObject, "")
                 };
+            }
         }
     }
 }

--- a/WindowsMonitor.Standard/Hardware/Win32ComputerSystem.cs
+++ b/WindowsMonitor.Standard/Hardware/Win32ComputerSystem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Management;
 
@@ -8,70 +8,70 @@ namespace WindowsMonitor.Hardware.Network
     /// </summary>
     public sealed class Win32ComputerSystem
     {
-		public ushort AdminPasswordStatus { get; private set; }
-		public bool AutomaticManagedPagefile { get; private set; }
-		public bool AutomaticResetBootOption { get; private set; }
-		public bool AutomaticResetCapability { get; private set; }
-		public ushort BootOptionOnLimit { get; private set; }
-		public ushort BootOptionOnWatchDog { get; private set; }
-		public bool BootRomSupported { get; private set; }
-		public ushort[] BootStatus { get; private set; }
-		public string BootupState { get; private set; }
-		public string Caption { get; private set; }
-		public ushort ChassisBootupState { get; private set; }
-		public string ChassisSkuNumber { get; private set; }
-		public string CreationClassName { get; private set; }
-		public string CurrentTimeZone { get; private set; }
-		public bool DaylightInEffect { get; private set; }
-		public string Description { get; private set; }
-		public string DnsHostName { get; private set; }
-		public string Domain { get; private set; }
-		public ushort DomainRole { get; private set; }
-		public bool EnableDaylightSavingsTime { get; private set; }
-		public ushort FrontPanelResetStatus { get; private set; }
-		public bool HypervisorPresent { get; private set; }
-		public bool InfraredSupported { get; private set; }
-		public string[] InitialLoadInfo { get; private set; }
-		public DateTime InstallDate { get; private set; }
-		public ushort KeyboardPasswordStatus { get; private set; }
-		public string LastLoadInfo { get; private set; }
-		public string Manufacturer { get; private set; }
-		public string Model { get; private set; }
-		public string Name { get; private set; }
-		public string NameFormat { get; private set; }
-		public bool NetworkServerModeEnabled { get; private set; }
-		public uint NumberOfLogicalProcessors { get; private set; }
-		public uint NumberOfProcessors { get; private set; }
-		public byte[] OemLogoBitmap { get; private set; }
-		public string[] OemStringArray { get; private set; }
-		public bool PartOfDomain { get; private set; }
-		public long PauseAfterReset { get; private set; }
-		public ushort PcSystemType { get; private set; }
-		public ushort PcSystemTypeEx { get; private set; }
-		public ushort[] PowerManagementCapabilities { get; private set; }
-		public bool PowerManagementSupported { get; private set; }
-		public ushort PowerOnPasswordStatus { get; private set; }
-		public ushort PowerState { get; private set; }
-		public ushort PowerSupplyState { get; private set; }
-		public string PrimaryOwnerContact { get; private set; }
-		public string PrimaryOwnerName { get; private set; }
-		public ushort ResetCapability { get; private set; }
-		public string ResetCount { get; private set; }
-		public string ResetLimit { get; private set; }
-		public string[] Roles { get; private set; }
-		public string Status { get; private set; }
-		public string[] SupportContactDescription { get; private set; }
-		public string SystemFamily { get; private set; }
-		public string SystemSkuNumber { get; private set; }
-		public ushort SystemStartupDelay { get; private set; }
-		public string[] SystemStartupOptions { get; private set; }
-		public byte SystemStartupSetting { get; private set; }
-		public string SystemType { get; private set; }
-		public ushort ThermalState { get; private set; }
-		public ulong TotalPhysicalMemory { get; private set; }
-		public string UserName { get; private set; }
-		public ushort WakeUpType { get; private set; }
-		public string Workgroup { get; private set; }
+        public ushort AdminPasswordStatus { get; private set; }
+        public bool AutomaticManagedPagefile { get; private set; }
+        public bool AutomaticResetBootOption { get; private set; }
+        public bool AutomaticResetCapability { get; private set; }
+        public ushort BootOptionOnLimit { get; private set; }
+        public ushort BootOptionOnWatchDog { get; private set; }
+        public bool BootRomSupported { get; private set; }
+        public ushort[] BootStatus { get; private set; }
+        public string BootupState { get; private set; }
+        public string Caption { get; private set; }
+        public ushort ChassisBootupState { get; private set; }
+        public string ChassisSkuNumber { get; private set; }
+        public string CreationClassName { get; private set; }
+        public string CurrentTimeZone { get; private set; }
+        public bool DaylightInEffect { get; private set; }
+        public string Description { get; private set; }
+        public string DnsHostName { get; private set; }
+        public string Domain { get; private set; }
+        public ushort DomainRole { get; private set; }
+        public bool EnableDaylightSavingsTime { get; private set; }
+        public ushort FrontPanelResetStatus { get; private set; }
+        public bool HypervisorPresent { get; private set; }
+        public bool InfraredSupported { get; private set; }
+        public string[] InitialLoadInfo { get; private set; }
+        public DateTime InstallDate { get; private set; }
+        public ushort KeyboardPasswordStatus { get; private set; }
+        public string LastLoadInfo { get; private set; }
+        public string Manufacturer { get; private set; }
+        public string Model { get; private set; }
+        public string Name { get; private set; }
+        public string NameFormat { get; private set; }
+        public bool NetworkServerModeEnabled { get; private set; }
+        public uint NumberOfLogicalProcessors { get; private set; }
+        public uint NumberOfProcessors { get; private set; }
+        public byte[] OemLogoBitmap { get; private set; }
+        public string[] OemStringArray { get; private set; }
+        public bool PartOfDomain { get; private set; }
+        public long PauseAfterReset { get; private set; }
+        public ushort PcSystemType { get; private set; }
+        public ushort PcSystemTypeEx { get; private set; }
+        public ushort[] PowerManagementCapabilities { get; private set; }
+        public bool PowerManagementSupported { get; private set; }
+        public ushort PowerOnPasswordStatus { get; private set; }
+        public ushort PowerState { get; private set; }
+        public ushort PowerSupplyState { get; private set; }
+        public string PrimaryOwnerContact { get; private set; }
+        public string PrimaryOwnerName { get; private set; }
+        public ushort ResetCapability { get; private set; }
+        public string ResetCount { get; private set; }
+        public string ResetLimit { get; private set; }
+        public string[] Roles { get; private set; }
+        public string Status { get; private set; }
+        public string[] SupportContactDescription { get; private set; }
+        public string SystemFamily { get; private set; }
+        public string SystemSkuNumber { get; private set; }
+        public ushort SystemStartupDelay { get; private set; }
+        public string[] SystemStartupOptions { get; private set; }
+        public byte SystemStartupSetting { get; private set; }
+        public string SystemType { get; private set; }
+        public ushort ThermalState { get; private set; }
+        public ulong TotalPhysicalMemory { get; private set; }
+        public string UserName { get; private set; }
+        public ushort WakeUpType { get; private set; }
+        public string Workgroup { get; private set; }
 
         public static IEnumerable<Win32ComputerSystem> Retrieve(string remote, string username, string password)
         {
@@ -94,6 +94,29 @@ namespace WindowsMonitor.Hardware.Network
             return Retrieve(managementScope);
         }
 
+        public static T ReturnDetail<T>(String Name, ManagementObject obj, T DefaultObj)
+        {
+            try
+            {
+                if (obj.Properties[Name] != null)
+                {
+                    if (obj.Properties[Name].Value != null)
+                    {
+                        return (T)(obj.Properties[Name].Value);
+                    }
+                    else
+                    {
+                        return DefaultObj;
+                    }
+                }
+                else
+                {
+                    return DefaultObj;
+                }
+            }
+            catch { return DefaultObj; }
+        }
+
         public static IEnumerable<Win32ComputerSystem> Retrieve(ManagementScope managementScope)
         {
             var objectQuery = new ObjectQuery("SELECT * FROM Win32_ComputerSystem");
@@ -103,70 +126,70 @@ namespace WindowsMonitor.Hardware.Network
             foreach (ManagementObject managementObject in objectCollection)
                 yield return new Win32ComputerSystem
                 {
-                     AdminPasswordStatus = (ushort) (managementObject.Properties["AdminPasswordStatus"]?.Value ?? default(ushort)),
-		 AutomaticManagedPagefile = (bool) (managementObject.Properties["AutomaticManagedPagefile"]?.Value ?? default(bool)),
-		 AutomaticResetBootOption = (bool) (managementObject.Properties["AutomaticResetBootOption"]?.Value ?? default(bool)),
-		 AutomaticResetCapability = (bool) (managementObject.Properties["AutomaticResetCapability"]?.Value ?? default(bool)),
-		 BootOptionOnLimit = (ushort) (managementObject.Properties["BootOptionOnLimit"]?.Value ?? default(ushort)),
-		 BootOptionOnWatchDog = (ushort) (managementObject.Properties["BootOptionOnWatchDog"]?.Value ?? default(ushort)),
-		 BootRomSupported = (bool) (managementObject.Properties["BootROMSupported"]?.Value ?? default(bool)),
-		 BootStatus = (ushort[]) (managementObject.Properties["BootStatus"]?.Value ?? new ushort[0]),
-		 BootupState = (string) (managementObject.Properties["BootupState"]?.Value),
-		 Caption = (string) (managementObject.Properties["Caption"]?.Value),
-		 ChassisBootupState = (ushort) (managementObject.Properties["ChassisBootupState"]?.Value ?? default(ushort)),
-		 ChassisSkuNumber = (string) (managementObject.Properties["ChassisSKUNumber"]?.Value),
-		 CreationClassName = (string) (managementObject.Properties["CreationClassName"]?.Value),
-		 CurrentTimeZone =  (managementObject.Properties["CurrentTimeZone"]?.Value?.ToString()),
-		 DaylightInEffect = (bool) (managementObject.Properties["DaylightInEffect"]?.Value ?? default(bool)),
-		 Description = (string) (managementObject.Properties["Description"]?.Value),
-		 DnsHostName = (string) (managementObject.Properties["DNSHostName"]?.Value),
-		 Domain = (string) (managementObject.Properties["Domain"]?.Value),
-		 DomainRole = (ushort) (managementObject.Properties["DomainRole"]?.Value ?? default(ushort)),
-		 EnableDaylightSavingsTime = (bool) (managementObject.Properties["EnableDaylightSavingsTime"]?.Value ?? default(bool)),
-		 FrontPanelResetStatus = (ushort) (managementObject.Properties["FrontPanelResetStatus"]?.Value ?? default(ushort)),
-		 HypervisorPresent = (bool) (managementObject.Properties["HypervisorPresent"]?.Value ?? default(bool)),
-		 InfraredSupported = (bool) (managementObject.Properties["InfraredSupported"]?.Value ?? default(bool)),
-		 InitialLoadInfo = (string[]) (managementObject.Properties["InitialLoadInfo"]?.Value ?? new string[0]),
-		 InstallDate = ManagementDateTimeConverter.ToDateTime (managementObject.Properties["InstallDate"]?.Value as string ?? "00010102000000.000000+060"),
-		 KeyboardPasswordStatus = (ushort) (managementObject.Properties["KeyboardPasswordStatus"]?.Value ?? default(ushort)),
-		 LastLoadInfo = (string) (managementObject.Properties["LastLoadInfo"]?.Value),
-		 Manufacturer = (string) (managementObject.Properties["Manufacturer"]?.Value),
-		 Model = (string) (managementObject.Properties["Model"]?.Value),
-		 Name = (string) (managementObject.Properties["Name"]?.Value),
-		 NameFormat = (string) (managementObject.Properties["NameFormat"]?.Value),
-		 NetworkServerModeEnabled = (bool) (managementObject.Properties["NetworkServerModeEnabled"]?.Value ?? default(bool)),
-		 NumberOfLogicalProcessors = (uint) (managementObject.Properties["NumberOfLogicalProcessors"]?.Value ?? default(uint)),
-		 NumberOfProcessors = (uint) (managementObject.Properties["NumberOfProcessors"]?.Value ?? default(uint)),
-		 OemLogoBitmap = (byte[]) (managementObject.Properties["OEMLogoBitmap"]?.Value ?? new byte[0]),
-		 OemStringArray = (string[]) (managementObject.Properties["OEMStringArray"]?.Value ?? new string[0]),
-		 PartOfDomain = (bool) (managementObject.Properties["PartOfDomain"]?.Value ?? default(bool)),
-		 PauseAfterReset = (long) (managementObject.Properties["PauseAfterReset"]?.Value ?? default(long)),
-		 PcSystemType = (ushort) (managementObject.Properties["PCSystemType"]?.Value ?? default(ushort)),
-		 PcSystemTypeEx = (ushort) (managementObject.Properties["PCSystemTypeEx"]?.Value ?? default(ushort)),
-		 PowerManagementCapabilities = (ushort[]) (managementObject.Properties["PowerManagementCapabilities"]?.Value ?? new ushort[0]),
-		 PowerManagementSupported = (bool) (managementObject.Properties["PowerManagementSupported"]?.Value ?? default(bool)),
-		 PowerOnPasswordStatus = (ushort) (managementObject.Properties["PowerOnPasswordStatus"]?.Value ?? default(ushort)),
-		 PowerState = (ushort) (managementObject.Properties["PowerState"]?.Value ?? default(ushort)),
-		 PowerSupplyState = (ushort) (managementObject.Properties["PowerSupplyState"]?.Value ?? default(ushort)),
-		 PrimaryOwnerContact = (string) (managementObject.Properties["PrimaryOwnerContact"]?.Value),
-		 PrimaryOwnerName = (string) (managementObject.Properties["PrimaryOwnerName"]?.Value),
-		 ResetCapability = (ushort) (managementObject.Properties["ResetCapability"]?.Value ?? default(ushort)),
-		 ResetCount =  (managementObject.Properties["ResetCount"]?.Value?.ToString()),
-		 ResetLimit =  (managementObject.Properties["ResetLimit"]?.Value?.ToString()),
-		 Roles = (string[]) (managementObject.Properties["Roles"]?.Value ?? new string[0]),
-		 Status = (string) (managementObject.Properties["Status"]?.Value),
-		 SupportContactDescription = (string[]) (managementObject.Properties["SupportContactDescription"]?.Value ?? new string[0]),
-		 SystemFamily = (string) (managementObject.Properties["SystemFamily"]?.Value),
-		 SystemSkuNumber = (string) (managementObject.Properties["SystemSKUNumber"]?.Value),
-		 SystemStartupDelay = (ushort) (managementObject.Properties["SystemStartupDelay"]?.Value ?? default(ushort)),
-		 SystemStartupOptions = (string[]) (managementObject.Properties["SystemStartupOptions"]?.Value ?? new string[0]),
-		 SystemStartupSetting = (byte) (managementObject.Properties["SystemStartupSetting"]?.Value ?? default(byte)),
-		 SystemType = (string) (managementObject.Properties["SystemType"]?.Value),
-		 ThermalState = (ushort) (managementObject.Properties["ThermalState"]?.Value ?? default(ushort)),
-		 TotalPhysicalMemory = (ulong) (managementObject.Properties["TotalPhysicalMemory"]?.Value ?? default(ulong)),
-		 UserName = (string) (managementObject.Properties["UserName"]?.Value),
-		 WakeUpType = (ushort) (managementObject.Properties["WakeUpType"]?.Value ?? default(ushort)),
-		 Workgroup = (string) (managementObject.Properties["Workgroup"]?.Value)
+                    AdminPasswordStatus = ReturnDetail<ushort>("AdminPasswordStatus", managementObject, default(ushort)),
+                    AutomaticManagedPagefile = ReturnDetail<bool>("AutomaticManagedPagefile", managementObject, default(bool)),
+                    AutomaticResetBootOption = ReturnDetail<bool>("AutomaticResetBootOption", managementObject, default(bool)),
+                    AutomaticResetCapability = ReturnDetail<bool>("AutomaticResetCapability", managementObject, default(bool)),
+                    BootOptionOnLimit = ReturnDetail<ushort>("BootOptionOnLimit", managementObject, default(ushort)),
+                    BootOptionOnWatchDog = ReturnDetail<ushort>("BootOptionOnWatchDog", managementObject, default(ushort)),
+                    BootRomSupported = ReturnDetail<bool>("BootROMSupported", managementObject, default(bool)),
+                    BootStatus = ReturnDetail<ushort[]>("BootStatus", managementObject, new ushort[0]),
+                    BootupState = ReturnDetail<string>("BootupState", managementObject, ""),
+                    Caption = ReturnDetail<string>("Caption", managementObject, ""),
+                    ChassisBootupState = ReturnDetail<ushort>("ChassisBootupState", managementObject, default(ushort)),
+                    ChassisSkuNumber = ReturnDetail<string>("ChassisSKUNumber", managementObject, ""),
+                    CreationClassName = ReturnDetail<string>("CreationClassName", managementObject, ""),
+                    CurrentTimeZone = ReturnDetail<string>("CurrentTimeZone", managementObject, ""),
+                    DaylightInEffect = ReturnDetail<bool>("DaylightInEffect", managementObject, default(bool)),
+                    Description = ReturnDetail<string>("Description", managementObject, ""),
+                    DnsHostName = ReturnDetail<string>("DNSHostName", managementObject, ""),
+                    Domain = ReturnDetail<string>("Domain", managementObject, ""),
+                    DomainRole = ReturnDetail<ushort>("DomainRole", managementObject, default(ushort)),
+                    EnableDaylightSavingsTime = ReturnDetail<bool>("EnableDaylightSavingsTime", managementObject, default(bool)),
+                    FrontPanelResetStatus = ReturnDetail<ushort>("FrontPanelResetStatus", managementObject, default(ushort)),
+                    HypervisorPresent = ReturnDetail<bool>("HypervisorPresent", managementObject, default(bool)),
+                    InfraredSupported = ReturnDetail<bool>("InfraredSupported", managementObject, default(bool)),
+                    InitialLoadInfo = ReturnDetail<string[]>("InitialLoadInfo", managementObject, new string[0]),
+                    InstallDate = ManagementDateTimeConverter.ToDateTime(ReturnDetail<string>("InstallDate", managementObject, "00010102000000.000000+060")),
+                    KeyboardPasswordStatus = ReturnDetail<ushort>("KeyboardPasswordStatus", managementObject, default(ushort)),
+                    LastLoadInfo = ReturnDetail<string>("LastLoadInfo", managementObject, ""),
+                    Manufacturer = ReturnDetail<string>("Manufacturer", managementObject, ""),
+                    Model = ReturnDetail<string>("Model", managementObject, ""),
+                    Name = ReturnDetail<string>("Name", managementObject, ""),
+                    NameFormat = ReturnDetail<string>("NameFormat", managementObject, ""),
+                    NetworkServerModeEnabled = ReturnDetail<bool>("NetworkServerModeEnabled", managementObject, default(bool)),
+                    NumberOfLogicalProcessors = ReturnDetail<uint>("NumberOfLogicalProcessors", managementObject, default(uint)),
+                    NumberOfProcessors = ReturnDetail<uint>("NumberOfProcessors", managementObject, default(uint)),
+                    OemLogoBitmap = ReturnDetail<byte[]>("OEMLogoBitmap", managementObject, new byte[0]),
+                    OemStringArray = ReturnDetail<string[]>("OEMStringArray", managementObject, new string[0]),
+                    PartOfDomain = ReturnDetail<bool>("PartOfDomain", managementObject, default(bool)),
+                    PauseAfterReset = ReturnDetail<long>("PauseAfterReset", managementObject, default(long)),
+                    PcSystemType = ReturnDetail<ushort>("PCSystemType", managementObject, default(ushort)),
+                    PcSystemTypeEx = ReturnDetail<ushort>("PCSystemTypeEx", managementObject, default(ushort)),
+                    PowerManagementCapabilities = (ushort[])(managementObject.Properties["PowerManagementCapabilities"]?.Value ?? new ushort[0]),
+                    PowerManagementSupported = ReturnDetail<bool>("PowerManagementSupported", managementObject, default(bool)),
+                    PowerOnPasswordStatus = ReturnDetail<ushort>("PowerOnPasswordStatus", managementObject, default(ushort)),
+                    PowerState = ReturnDetail<ushort>("PowerState", managementObject, default(ushort)),
+                    PowerSupplyState = ReturnDetail<ushort>("PowerSupplyState", managementObject, default(ushort)),
+                    PrimaryOwnerContact = ReturnDetail<string>("PrimaryOwnerContact", managementObject, ""),
+                    PrimaryOwnerName = ReturnDetail<string>("PrimaryOwnerName", managementObject, ""),
+                    ResetCapability = ReturnDetail<ushort>("ResetCapability", managementObject, default(ushort)),
+                    ResetCount = ReturnDetail<string>("ResetCount", managementObject, ""),
+                    ResetLimit = ReturnDetail<string>("ResetLimit", managementObject, ""),
+                    Roles = ReturnDetail<string[]>("Roles", managementObject, new string[0]),
+                    Status = ReturnDetail<string>("Status", managementObject, ""),
+                    SupportContactDescription = ReturnDetail<string[]>("SupportContactDescription", managementObject, new string[0]),
+                    SystemFamily = ReturnDetail<string>("SystemFamily", managementObject, ""),
+                    SystemSkuNumber = ReturnDetail<string>("SystemSKUNumber", managementObject, ""),
+                    SystemStartupDelay = ReturnDetail<ushort>("SystemStartupDelay", managementObject, default(ushort)),
+                    SystemStartupOptions = ReturnDetail<string[]>("SystemStartupOptions", managementObject, new string[0]),
+                    SystemStartupSetting = ReturnDetail<byte>("SystemStartupSetting", managementObject, default(byte)),
+                    SystemType = ReturnDetail<string>("SystemType", managementObject, ""),
+                    ThermalState = ReturnDetail<ushort>("ThermalState", managementObject, default(ushort)),
+                    TotalPhysicalMemory = ReturnDetail<ulong>("TotalPhysicalMemory", managementObject, default(ulong)),
+                    UserName = ReturnDetail<string>("UserName", managementObject, ""),
+                    WakeUpType = ReturnDetail<ushort>("WakeUpType", managementObject, default(ushort)),
+                    Workgroup = ReturnDetail<string>("Workgroup", managementObject, "")
                 };
         }
     }

--- a/WindowsMonitor.Standard/Windows/Win32OperatingSystem.cs
+++ b/WindowsMonitor.Standard/Windows/Win32OperatingSystem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Management;
 
@@ -93,6 +93,28 @@ namespace WindowsMonitor.Windows
             var managementScope = new ManagementScope(new ManagementPath("root\\cimv2"));
             return Retrieve(managementScope);
         }
+        public static T ReturnDetail<T>(String Name, ManagementObject obj, T DefaultObj)
+        {
+            try
+            {
+                if (obj.Properties[Name] != null)
+                {
+                    if (obj.Properties[Name].Value != null)
+                    {
+                        return (T)(obj.Properties[Name].Value);
+                    }
+                    else
+                    {
+                        return DefaultObj;
+                    }
+                }
+                else
+                {
+                    return DefaultObj;
+                }
+            }
+            catch { return DefaultObj; }
+        }
 
         public static IEnumerable<Win32OperatingSystem> Retrieve(ManagementScope managementScope)
         {
@@ -103,101 +125,70 @@ namespace WindowsMonitor.Windows
             foreach (ManagementObject managementObject in objectCollection)
                 yield return new Win32OperatingSystem
                 {
-                    BootDevice = (string) (managementObject.Properties["BootDevice"]?.Value),
-                    BuildNumber = (string) (managementObject.Properties["BuildNumber"]?.Value),
-                    BuildType = (string) (managementObject.Properties["BuildType"]?.Value),
-                    Caption = (string) (managementObject.Properties["Caption"]?.Value),
-                    CodeSet = (string) (managementObject.Properties["CodeSet"]?.Value),
-                    CountryCode = (string) (managementObject.Properties["CountryCode"]?.Value),
-                    CreationClassName =
-                        (string) (managementObject.Properties["CreationClassName"]?.Value),
-                    CsCreationClassName =
-                        (string) (managementObject.Properties["CSCreationClassName"]?.Value),
-                    CsdVersion = (string) (managementObject.Properties["CSDVersion"]?.Value),
-                    CsName = (string) (managementObject.Properties["CSName"]?.Value),
-                    CurrentTimeZone =  (managementObject.Properties["CurrentTimeZone"]?.Value?.ToString()),
-                    DataExecutionPrevention32BitApplications =
-                        (bool) (managementObject.Properties["DataExecutionPrevention_32BitApplications"]?.Value ??
-                                default(bool)),
-                    DataExecutionPreventionAvailable =
-                        (bool) (managementObject.Properties["DataExecutionPrevention_Available"]?.Value ??
-                                default(bool)),
-                    DataExecutionPreventionDrivers =
-                        (bool) (managementObject.Properties["DataExecutionPrevention_Drivers"]?.Value ?? default(bool)),
-                    DataExecutionPreventionSupportPolicy =
-                        (byte) (managementObject.Properties["DataExecutionPrevention_SupportPolicy"]?.Value ??
-                                default(byte)),
-                    Debug = (bool) (managementObject.Properties["Debug"]?.Value ?? default(bool)),
-                    Description = (string) (managementObject.Properties["Description"]?.Value),
-                    Distributed = (bool) (managementObject.Properties["Distributed"]?.Value ?? default(bool)),
-                    EncryptionLevel = (uint) (managementObject.Properties["EncryptionLevel"]?.Value ?? default(uint)),
-                    ForegroundApplicationBoost =
-                        (byte) (managementObject.Properties["ForegroundApplicationBoost"]?.Value ?? default(byte)),
-                    FreePhysicalMemory =
-                        (ulong) (managementObject.Properties["FreePhysicalMemory"]?.Value ?? default(ulong)),
-                    FreeSpaceInPagingFiles =
-                        (ulong) (managementObject.Properties["FreeSpaceInPagingFiles"]?.Value ?? default(ulong)),
-                    FreeVirtualMemory =
-                        (ulong) (managementObject.Properties["FreeVirtualMemory"]?.Value ?? default(ulong)),
-                    InstallDate = ManagementDateTimeConverter.ToDateTime (managementObject.Properties["InstallDate"]?.Value as string ?? "00010102000000.000000+060"),
-                    LargeSystemCache = (uint) (managementObject.Properties["LargeSystemCache"]?.Value ?? default(uint)),
-                    LastBootUpTime =
-                        ManagementDateTimeConverter.ToDateTime (managementObject.Properties["LastBootUpTime"]?.Value as string ?? "00010102000000.000000+060"),
-                    LocalDateTime =
-                        ManagementDateTimeConverter.ToDateTime (managementObject.Properties["LocalDateTime"]?.Value as string ?? "00010102000000.000000+060"),
-                    Locale = (string) (managementObject.Properties["Locale"]?.Value),
-                    Manufacturer = (string) (managementObject.Properties["Manufacturer"]?.Value),
-                    MaxNumberOfProcesses =
-                        (uint) (managementObject.Properties["MaxNumberOfProcesses"]?.Value ?? default(uint)),
-                    MaxProcessMemorySize =
-                        (ulong) (managementObject.Properties["MaxProcessMemorySize"]?.Value ?? default(ulong)),
-                    MuiLanguages = (string[]) (managementObject.Properties["MUILanguages"]?.Value ?? new string[0]),
-                    Name = (string) (managementObject.Properties["Name"]?.Value),
-                    NumberOfLicensedUsers =
-                        (uint) (managementObject.Properties["NumberOfLicensedUsers"]?.Value ?? default(uint)),
-                    NumberOfProcesses =
-                        (uint) (managementObject.Properties["NumberOfProcesses"]?.Value ?? default(uint)),
-                    NumberOfUsers = (uint) (managementObject.Properties["NumberOfUsers"]?.Value ?? default(uint)),
-                    OperatingSystemSku =
-                        (uint) (managementObject.Properties["OperatingSystemSKU"]?.Value ?? default(uint)),
-                    Organization = (string) (managementObject.Properties["Organization"]?.Value),
-                    OsArchitecture = (string) (managementObject.Properties["OSArchitecture"]?.Value),
-                    OsLanguage = (uint) (managementObject.Properties["OSLanguage"]?.Value ?? default(uint)),
-                    OsProductSuite = (uint) (managementObject.Properties["OSProductSuite"]?.Value ?? default(uint)),
-                    OsType = (ushort) (managementObject.Properties["OSType"]?.Value ?? default(ushort)),
-                    OtherTypeDescription =
-                        (string) (managementObject.Properties["OtherTypeDescription"]?.Value),
-                    PaeEnabled = (bool) (managementObject.Properties["PAEEnabled"]?.Value ?? default(bool)),
-                    PlusProductId = (string) (managementObject.Properties["PlusProductID"]?.Value),
-                    PlusVersionNumber =
-                        (string) (managementObject.Properties["PlusVersionNumber"]?.Value),
-                    PortableOperatingSystem =
-                        (bool) (managementObject.Properties["PortableOperatingSystem"]?.Value ?? default(bool)),
-                    Primary = (bool) (managementObject.Properties["Primary"]?.Value ?? default(bool)),
-                    ProductType = (uint) (managementObject.Properties["ProductType"]?.Value ?? default(uint)),
-                    RegisteredUser = (string) (managementObject.Properties["RegisteredUser"]?.Value),
-                    SerialNumber = (string) (managementObject.Properties["SerialNumber"]?.Value),
-                    ServicePackMajorVersion =
-                        (ushort) (managementObject.Properties["ServicePackMajorVersion"]?.Value ?? default(ushort)),
-                    ServicePackMinorVersion =
-                        (ushort) (managementObject.Properties["ServicePackMinorVersion"]?.Value ?? default(ushort)),
-                    SizeStoredInPagingFiles =
-                        (ulong) (managementObject.Properties["SizeStoredInPagingFiles"]?.Value ?? default(ulong)),
-                    Status = (string) (managementObject.Properties["Status"]?.Value),
-                    SuiteMask = (uint) (managementObject.Properties["SuiteMask"]?.Value ?? default(uint)),
-                    SystemDevice = (string) (managementObject.Properties["SystemDevice"]?.Value),
-                    SystemDirectory =
-                        (string) (managementObject.Properties["SystemDirectory"]?.Value),
-                    SystemDrive = (string) (managementObject.Properties["SystemDrive"]?.Value),
-                    TotalSwapSpaceSize =
-                        (ulong) (managementObject.Properties["TotalSwapSpaceSize"]?.Value ?? default(ulong)),
-                    TotalVirtualMemorySize =
-                        (ulong) (managementObject.Properties["TotalVirtualMemorySize"]?.Value ?? default(ulong)),
-                    TotalVisibleMemorySize =
-                        (ulong) (managementObject.Properties["TotalVisibleMemorySize"]?.Value ?? default(ulong)),
-                    Version = (string) (managementObject.Properties["Version"]?.Value),
-                    WindowsDirectory =
-                        (string) (managementObject.Properties["WindowsDirectory"]?.Value)
+                    BootDevice = ReturnDetail<string>("BootDevice", managementObject, ""),
+                    BuildNumber = ReturnDetail<string>("BuildNumber", managementObject, ""),
+                    BuildType = ReturnDetail<string>("BuildType", managementObject, ""),
+                    Caption = ReturnDetail<string>("Caption", managementObject, ""),
+                    CodeSet = ReturnDetail<string>("CodeSet", managementObject, ""),
+                    CountryCode = ReturnDetail<string>("CountryCode", managementObject, ""),
+                    CreationClassName = ReturnDetail<string>("CreationClassName", managementObject, ""),
+                    CsCreationClassName = ReturnDetail<string>("CSCreationClassName", managementObject, ""),
+                    CsdVersion = ReturnDetail<string>("CSDVersion", managementObject, ""),
+                    CsName = ReturnDetail<string>("CSName", managementObject, ""),
+                    CurrentTimeZone = ReturnDetail<string>("CurrentTimeZone", managementObject, ""),
+                    DataExecutionPrevention32BitApplications = ReturnDetail<bool>("DataExecutionPrevention_32BitApplications", managementObject, default(bool)),
+                    DataExecutionPreventionAvailable = ReturnDetail<bool>("DataExecutionPrevention_Available", managementObject, default(bool)),
+                    DataExecutionPreventionDrivers = ReturnDetail<bool>("DataExecutionPrevention_Drivers", managementObject, default(bool)),
+                    DataExecutionPreventionSupportPolicy = ReturnDetail<byte>("DataExecutionPrevention_SupportPolicy", managementObject, default(byte)),
+                    Debug = ReturnDetail<bool>("Debug", managementObject, default(bool)),
+                    Description = ReturnDetail<string>("Description", managementObject, ""),
+                    Distributed = ReturnDetail<bool>("Distributed", managementObject, default(bool)),
+                    EncryptionLevel = ReturnDetail<uint>("EncryptionLevel", managementObject, default(uint)),
+                    ForegroundApplicationBoost = ReturnDetail<byte>("ForegroundApplicationBoost", managementObject, default(byte)),
+                    FreePhysicalMemory = ReturnDetail<ulong>("FreePhysicalMemory", managementObject, default(ulong)),
+                    FreeSpaceInPagingFiles = ReturnDetail<ulong>("FreeSpaceInPagingFiles", managementObject, default(ulong)),
+                    FreeVirtualMemory = ReturnDetail<ulong>("FreeVirtualMemory", managementObject, default(ulong)),
+                    InstallDate = ManagementDateTimeConverter.ToDateTime(ReturnDetail<string>("InstallDate", managementObject, "00010102000000.000000+060")),
+                    LargeSystemCache = ReturnDetail<uint>("LargeSystemCache", managementObject, default(uint)),
+                    LastBootUpTime = ManagementDateTimeConverter.ToDateTime(ReturnDetail<string>("LastBootUpTime", managementObject, "00010102000000.000000+060")),
+                    LocalDateTime = ManagementDateTimeConverter.ToDateTime(ReturnDetail<string>("LocalDateTime", managementObject, "00010102000000.000000+060")),
+                    Locale = ReturnDetail<string>("Locale", managementObject, ""),
+                    Manufacturer = ReturnDetail<string>("Manufacturer", managementObject, ""),
+                    MaxNumberOfProcesses = ReturnDetail<uint>("MaxNumberOfProcesses", managementObject, default(uint)),
+                    MaxProcessMemorySize = ReturnDetail<ulong>("MaxProcessMemorySize", managementObject, default(ulong)),
+                    MuiLanguages = ReturnDetail<string[]>("MUILanguages", managementObject, new string[0]),
+                    Name = ReturnDetail<string>("Name", managementObject, ""),
+                    NumberOfLicensedUsers = ReturnDetail<uint>("NumberOfLicensedUsers", managementObject, default(uint)),
+                    NumberOfProcesses = ReturnDetail<uint>("NumberOfProcesses", managementObject, default(uint)),
+                    NumberOfUsers = ReturnDetail<uint>("NumberOfUsers", managementObject, default(uint)),
+                    OperatingSystemSku = ReturnDetail<uint>("OperatingSystemSKU", managementObject, default(uint)),
+                    Organization = ReturnDetail<string>("Organization", managementObject, ""),
+                    OsArchitecture = ReturnDetail<string>("OSArchitecture", managementObject, ""),
+                    OsLanguage = ReturnDetail<uint>("OSLanguage", managementObject, default(uint)),
+                    OsProductSuite = ReturnDetail<uint>("OSProductSuite", managementObject, default(uint)),
+                    OsType = ReturnDetail<ushort>("OSType", managementObject, default(ushort)),
+                    OtherTypeDescription = ReturnDetail<string>("OtherTypeDescription", managementObject, ""),
+                    PaeEnabled = ReturnDetail<bool>("PAEEnabled", managementObject, default(bool)),
+                    PlusProductId = ReturnDetail<string>("PlusProductID", managementObject, ""),
+                    PlusVersionNumber = ReturnDetail<string>("PlusVersionNumber", managementObject, ""),
+                    PortableOperatingSystem = ReturnDetail<bool>("PortableOperatingSystem", managementObject, default(bool)),
+                    Primary = ReturnDetail<bool>("Primary", managementObject, default(bool)),
+                    ProductType = ReturnDetail<uint>("ProductType", managementObject, default(uint)),
+                    RegisteredUser = ReturnDetail<string>("RegisteredUser", managementObject, ""),
+                    SerialNumber = ReturnDetail<string>("SerialNumber", managementObject, ""),
+                    ServicePackMajorVersion = ReturnDetail<ushort>("ServicePackMajorVersion", managementObject, default(ushort)),
+                    ServicePackMinorVersion = ReturnDetail<ushort>("ServicePackMinorVersion", managementObject, default(ushort)),
+                    SizeStoredInPagingFiles = ReturnDetail<ulong>("SizeStoredInPagingFiles", managementObject, default(ulong)),
+                    Status = ReturnDetail<string>("Status", managementObject, ""),
+                    SuiteMask = ReturnDetail<uint>("SuiteMask", managementObject, default(uint)),
+                    SystemDevice = ReturnDetail<string>("SystemDevice", managementObject, ""),
+                    SystemDirectory = ReturnDetail<string>("SystemDirectory", managementObject, ""),
+                    SystemDrive = ReturnDetail<string>("SystemDrive", managementObject, ""),
+                    TotalSwapSpaceSize = ReturnDetail<ulong>("TotalSwapSpaceSize", managementObject, default(ulong)),
+                    TotalVirtualMemorySize = ReturnDetail<ulong>("TotalVirtualMemorySize", managementObject, default(ulong)),
+                    TotalVisibleMemorySize = ReturnDetail<ulong>("TotalVisibleMemorySize", managementObject, default(ulong)),
+                    Version = ReturnDetail<string>("Version", managementObject, ""),
+                    WindowsDirectory = ReturnDetail<string>("WindowsDirectory", managementObject, "")
                 };
         }
     }


### PR DESCRIPTION
Implemented in a Project I'm using, With dotnet 5 I found that older windows versions weren't working anymore, Found the underlying cause to be something from System.Management, However improving the way the error checks are performed at least stopped the issues.

I'd probably suggest doing it to all the others, but that's hours of work, I might get around to it later.